### PR TITLE
fix: update theme light modes

### DIFF
--- a/lib/theme/widgets/theme_toggle.dart
+++ b/lib/theme/widgets/theme_toggle.dart
@@ -8,12 +8,11 @@ class ThemeToggle extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final state = context.watch<ThemeCubit>().state;
-    // FIXME: Something's not right here...
-    final label = state == ThemeState.light ? 'Dark Mode' : 'Light Mode';
-    final icon = state == ThemeState.light ? Icons.dark_mode : Icons.light_mode;
+    final label = state == ThemeState.light ? 'Light Mode' : 'Dark Mode';
+    final icon = state == ThemeState.light ? Icons.light_mode : Icons.dark_mode;
     return SwitchListTile(
       title: Text(label),
-      value: state == ThemeState.light,
+      value: state == ThemeState.dark,
       onChanged: (_) => context.read<ThemeCubit>().toggleTheme(),
       secondary: Icon(icon),
     );


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Issue: the light mode/toggle theme in the settings are inverted.
This PR synchronizes the option with theme state and changes order to light and dark (the common order in the apps).

Before:
![light_mode_bug](https://github.com/felangel/flutter_and_friends/assets/17673296/a1668070-c239-4ee7-9b8e-52974f65c836)

After:
![light_mode_fix](https://github.com/felangel/flutter_and_friends/assets/17673296/d58af668-2d25-4d66-8455-16446f29b901)

Update:
![light_mode_update](https://github.com/felangel/flutter_and_friends/assets/17673296/1f8d5d9b-5d69-4e08-a68f-6a37356a4b24)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
