### PR TITLE
docs: add generic privacy policy

### DIFF
--- a/privacy_policy.md
+++ b/privacy_policy.md
@@ -1,0 +1,111 @@
+# Privacy Policy
+
+**Last updated: July 29, 2026**
+
+Welcome to Flutter & Friends ("we," "our," or "us"). Your privacy is important to us, and we are committed to protecting your personal information. This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you use the official Flutter & Friends conference mobile application (the "App").
+
+By using the App, you agree to the collection and use of information in accordance with this policy. If you do not agree with this policy, please do not use the App.
+
+## 1. Information We Collect
+
+The App is designed to work without an account. We do not ask you to sign up, sign in, or provide us with your name, email address, or any other identifying information.
+
+### 1.1 Information You Provide
+
+- **Photos:** If you use the conference badge feature, you may select a photo from your device's photo library. The photo is processed on your device and transferred to your conference badge over NFC. It is not uploaded to us or to any server.
+- **Favorites:** Talks, workshops, and activities you mark as favorites.
+- **Preferences:** Your theme selection and other in-app settings.
+
+All of the above is stored locally on your device. We do not have access to it.
+
+### 1.2 Information Collected Automatically
+
+We do not run analytics, advertising, or tracking software in the App, and we do not build user profiles.
+
+The App does connect to Shorebird to check for over-the-air updates (see Section 3.1), which involves basic technical information such as your app version and platform. Depending on how you installed the App, Apple or Google may also collect installation and crash information on their own terms.
+
+### 1.3 Financial Information
+
+The App is free. There are no in-app purchases or subscriptions, and we do not collect or process any payment information.
+
+## 2. How We Use Your Information
+
+Information stored on your device is used only to:
+
+- Provide the App's features, such as your personal schedule of favorited sessions.
+- Remember your preferences between sessions.
+- Generate and transfer a badge image to conference badge hardware over NFC.
+- Deliver bug fixes and improvements through over-the-air updates.
+
+We do not sell, rent, or share your information, and we do not use it for advertising.
+
+## 3. Third-Party Services
+
+### 3.1 Shorebird (Over-the-Air Updates)
+
+The App uses [Shorebird](https://shorebird.dev) to deliver code updates without requiring a full app store release. When the App checks for updates, Shorebird receives technical information such as the app version, patch number, and platform. It does not receive your photos, favorites, or any personal content. See [Shorebird's Privacy Policy](https://shorebird.dev/privacy) for details.
+
+### 3.2 Apple App Store and Google Play
+
+The App is distributed through the Apple App Store and Google Play. These platforms collect information about downloads, installs, and crashes in accordance with their own policies. See [Apple's Privacy Policy](https://www.apple.com/legal/privacy/) and [Google's Privacy Policy](https://policies.google.com/privacy).
+
+### 3.3 External Links
+
+The App contains links to external websites, including the conference website, sponsor sites, social media profiles, and maps. Once you follow a link, you are subject to the privacy policy of that third party. We are not responsible for their practices.
+
+## 4. Data Storage and Security
+
+Your favorites, preferences, and badge images are stored in the App's local storage on your device. Nothing is transmitted to servers operated by us.
+
+If you use the badge feature, your selected image is written directly to the conference badge over NFC. Anyone with physical access to that badge can see the image displayed on it.
+
+Because your data lives on your device, its security also depends on your device's own protections, such as a passcode, biometric lock, and up-to-date operating system.
+
+## 5. Your Rights (GDPR & CCPA)
+
+We do not collect or store personal data on our servers, so in most cases there is no data for us to access, correct, export, or delete on your behalf. You remain in full control of the information stored on your device.
+
+### 5.1 For European Economic Area (EEA) Residents (GDPR)
+
+If you are located in the EEA, you have the right of access, rectification, erasure, restriction of processing, data portability, objection to processing, and withdrawal of consent. Because we do not hold your personal data, you can exercise these rights directly by clearing the App's data or uninstalling the App. You may still contact us with any question about this policy, and you have the right to lodge a complaint with your local data protection authority.
+
+### 5.2 For California Residents (CCPA)
+
+If you are a California resident, you have the right to know what personal information is collected, to request its deletion, to opt out of the sale of personal information, and to non-discrimination for exercising your rights. **We do not sell your personal information.**
+
+## 6. Data Retention
+
+We do not retain your personal data, because we do not collect it. Data stored locally on your device remains there until you delete it or uninstall the App.
+
+## 7. Deleting Your Data
+
+You can remove all data associated with the App at any time:
+
+- **iOS:** Delete the App from your device.
+- **Android:** Go to Settings → Apps → Flutter & Friends → Storage → Clear data, or uninstall the App.
+
+This removes your favorites, preferences, and any badge images stored by the App. This action cannot be undone.
+
+## 8. Children's Privacy
+
+The App is not directed at children under 13, and we do not knowingly collect personal information from children under 13. If you believe a child has provided us with personal information, please contact us and we will address it promptly.
+
+## 9. International Data Transfers
+
+The App does not transfer your personal data internationally, because it does not send your personal data anywhere. Technical update requests to Shorebird, and any data collected by Apple or Google, may be processed in countries other than your own under those providers' own safeguards.
+
+## 10. Open Source
+
+The App is open source. You can review exactly what it does, including how it handles data, at [github.com/flutter-and-friends/flutter_and_friends](https://github.com/flutter-and-friends/flutter_and_friends).
+
+## 11. Changes to This Policy
+
+We may update this Privacy Policy from time to time. We will notify you of any material changes by posting the new Privacy Policy in this repository and updating the "Last updated" date above. Your continued use of the App after such changes constitutes your acceptance of the updated policy.
+
+## 12. Contact Us
+
+If you have any questions about this Privacy Policy or wish to exercise your data rights, please contact us at:
+
+**Flutter & Friends**
+Email: contact@flutterfriends.dev
+Website: [flutterfriends.dev](https://www.flutterfriends.dev)


### PR DESCRIPTION
## Description

Adds `privacy_policy.md`, a more complete privacy policy for the Flutter & Friends app. The existing `privacy.md` is left untouched.

The content is modeled on a standard app-store privacy policy structure (numbered sections, GDPR/CCPA rights, retention, deletion, contact), but written to match what the app actually does:

- **No accounts, no analytics, no purchases** — nothing is collected on our side.
- **Local-only storage** — favorites, theme preference, and badge images live in on-device storage (`hydrated_bloc`).
- **NFC badge photo flow** — selected photos are decoded on device and written to the badge over NFC; they are never uploaded.
- **Shorebird** — noted as the one outbound service, receiving app version/patch/platform for over-the-air updates.
- **App Store / Google Play** — noted as collecting install and crash data under their own policies.
- **Open source** — points to this repo so anyone can verify the above.

Contact address: `contact@flutterfriends.dev`.

## Notes

- The Settings page still links to `privacy.md` (`lib/settings/views/settings_page.dart:157`). Repointing it at this document is a deliberate follow-up decision, not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)