### PR TITLE
chore: bump friends_badge to ^0.1.5+1

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -420,10 +420,10 @@ packages:
     dependency: "direct main"
     description:
       name: friends_badge
-      sha256: "5fa53cfd8fbab64f63a6751c617389153f5d63903677440ec0fbfa762c42db07"
+      sha256: c617dcda912ebd64edb67888a2e54f5dfbd12f18f7e0908969891bb19c4f01dd
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.1.5+1"
   frontend_server_client:
     dependency: transitive
     description:
@@ -636,10 +636,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -652,10 +652,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -993,10 +993,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   timing:
     dependency: transitive
     description:
@@ -1113,10 +1113,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   very_good_analysis:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter_bloc: ^9.0.0
   flutter_svg: ^2.0.0
   font_awesome_flutter: ^11.0.0
-  friends_badge: ^0.1.3
+  friends_badge: ^0.1.5+1
   http: ^1.2.0
   hydrated_bloc: ^10.0.0
   image: ^4.5.4


### PR DESCRIPTION
## What

Bumps `friends_badge` from `^0.1.3` to `^0.1.5+1`.

## Why

`friends_badge 0.1.5+1` was released today and fixes a real problem for consumers: 0.1.5 still carried a stale `nfc_manager` git override (to a personal fork branch) that broke `pub get` for apps depending on it. 0.1.5+1 removes that override and moves to hosted `nfc_manager ^4.2.1`.

The app's direct `nfc_manager: ^4.1.0` constraint already allows 4.2.1, and its minimum SDK constraints (`sdk: >=3.10.0`, `flutter: >=3.38.1`) satisfy the package's new minimums (`sdk: ^3.11.4`, `flutter: >=3.41.6`).

## Verification

- `flutter pub get` — resolves clean (lockfile: friends_badge 0.1.5+1, nfc_manager 4.2.1)
- `flutter analyze` — 0 errors (only pre-existing info lints; repo has no test suite)
- `flutter build web --release` — builds successfully, confirming the new web support (#48) works with the bump